### PR TITLE
add basic support for `kubectl logs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 # IDE files
 .vscode
 .idea
+__debug_bin

--- a/pkg/api/logs.go
+++ b/pkg/api/logs.go
@@ -47,7 +47,7 @@ func (h handler) getAPIV1NamespaceResourceLog(w http.ResponseWriter, r *http.Req
 			return
 		}
 	}
-	PlainText(w, http.StatusAccepted, data)
+	PlainText(w, http.StatusOK, data)
 }
 
 func PlainText(w http.ResponseWriter, responseCode int, responseBody []byte) {

--- a/pkg/api/logs.go
+++ b/pkg/api/logs.go
@@ -36,8 +36,8 @@ func (h handler) getAPIV1NamespaceResourceLog(w http.ResponseWriter, r *http.Req
 			data, err = ioutil.ReadFile(errFileName)
 			if err != nil {
 				if os.IsNotExist(err) {
-					w.Write([]byte(fmt.Sprintf("log files not found in support-bundle.\n%v\n%v", fileName, errFileName)))
-					w.WriteHeader(http.StatusNotFound)
+					PlainText(w, http.StatusNotFound, []byte(fmt.Sprintf("log files not found in support-bundle.\n%v\n%v", fileName, errFileName)))
+					return
 				}
 				w.WriteHeader(http.StatusInternalServerError)
 				return
@@ -47,8 +47,11 @@ func (h handler) getAPIV1NamespaceResourceLog(w http.ResponseWriter, r *http.Req
 			return
 		}
 	}
+	PlainText(w, http.StatusAccepted, data)
+}
 
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusAccepted)
-	w.Write(data)
+func PlainText(w http.ResponseWriter, responseCode int, responseBody []byte) {
+	w.Header().Set("Content-Type", "text/plain")
+	w.Write(responseBody)
+	w.WriteHeader(responseCode)
 }

--- a/pkg/api/logs.go
+++ b/pkg/api/logs.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/gorilla/mux"
 )
@@ -18,8 +19,14 @@ func (h handler) getAPIV1NamespaceResourceLog(w http.ResponseWriter, r *http.Req
 	resource := mux.Vars(r)["resource"]
 	name := mux.Vars(r)["name"]
 	container := r.URL.Query().Get("container")
+	previous, _ := strconv.ParseBool(r.URL.Query().Get("previous"))
 
-	fileName := filepath.Join(h.clusterData.ClusterResourcesDir, resource, "logs", namespace, name, fmt.Sprintf("%s.log", container))
+	logFileName := fmt.Sprintf("%s.log", container)
+	if previous {
+		logFileName = fmt.Sprintf("%s-previous.log", container)
+	}
+
+	fileName := filepath.Join(h.clusterData.ClusterResourcesDir, resource, "logs", namespace, name, logFileName)
 	data, err := ioutil.ReadFile(fileName)
 	if err != nil {
 		log.Println("failed to load file", err)

--- a/pkg/api/logs.go
+++ b/pkg/api/logs.go
@@ -1,0 +1,47 @@
+package api
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/gorilla/mux"
+)
+
+func (h handler) getAPIV1NamespaceResourceLog(w http.ResponseWriter, r *http.Request) {
+	log.Println("called getAPIV1NamespaceResourceLog")
+
+	namespace := mux.Vars(r)["namespace"]
+	resource := mux.Vars(r)["resource"]
+	name := mux.Vars(r)["name"]
+	container := r.URL.Query().Get("container")
+
+	fileName := filepath.Join(h.clusterData.ClusterResourcesDir, resource, "logs", namespace, name, fmt.Sprintf("%s.log", container))
+	data, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		log.Println("failed to load file", err)
+		if os.IsNotExist(err) {
+			// try reading from -logs-errors.log file
+			errFileName := filepath.Join(h.clusterData.ClusterResourcesDir, resource, "logs", namespace, name, fmt.Sprintf("%s-logs-errors.log", container))
+			data, err = ioutil.ReadFile(errFileName)
+			if err != nil {
+				if os.IsNotExist(err) {
+					w.Write([]byte(fmt.Sprintf("log files not found in support-bundle.\n%v\n%v", fileName, errFileName)))
+					w.WriteHeader(http.StatusNotFound)
+				}
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	w.Write(data)
+}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -80,6 +80,7 @@ func StartAPIServer(clusterData sbctl.ClusterData) (string, error) {
 	apiv1Router.HandleFunc("/{resource}/{name}", h.getAPIV1ClusterResource)
 	apiv1Router.HandleFunc("/namespaces/{namespace}/{resource}", h.getAPIV1NamespaceResources)
 	apiv1Router.HandleFunc("/namespaces/{namespace}/{resource}/{name}", h.getAPIV1NamespaceResource)
+	apiv1Router.HandleFunc("/namespaces/{namespace}/{resource}/{name}/log", h.getAPIV1NamespaceResourceLog)
 
 	r.HandleFunc("/apis", h.getAPIs)
 	apisRouter := r.PathPrefix("/apis").Subrouter()

--- a/pkg/sbctl/compatibility.go
+++ b/pkg/sbctl/compatibility.go
@@ -15,8 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubectl/pkg/scheme"
-	storagev1 "k8s.io/api/storage/v1"
-
 )
 
 func Decode(resource string, data []byte) (runtime.Object, *schema.GroupVersionKind, error) {

--- a/pkg/sbctl/compatibility.go
+++ b/pkg/sbctl/compatibility.go
@@ -15,6 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubectl/pkg/scheme"
+	storagev1 "k8s.io/api/storage/v1"
+
 )
 
 func Decode(resource string, data []byte) (runtime.Object, *schema.GroupVersionKind, error) {


### PR DESCRIPTION
 **add basic support for `kubectl logs`**

If the pod logs are collected as part of support-bundle, they are saved in the path 
`/cluster-resources/pods/logs/{namespace}/{pod}/{container}.log` or
`/cluster-resources/pods/logs/{namespace}/{pod}/{container}-errors-logs.log`
the log files are parsed and data is returned accordingly 
**console log:**
```shell
# when .log file present
➜ k logs -n monitoring kube-state-metrics-f97897479-cf57l  -c kube-state-metrics
I0207 20:14:40.033567       1 main.go:117] Using all namespace
I0207 20:14:40.033617       1 main.go:138] metric allow-denylisting: Excluding the following lists that were on denylist:
W0207 20:14:40.033690       1 client_config.go:615] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0207 20:14:40.037317       1 main.go:239] Testing communication with server
F0207 20:14:40.038600       1 main.go:148] Failed to create client: error while trying to communicate with apiserver: Get "https://***HIDDEN***:443/version?timeout=32s": dial tcp ***HIDDEN***:443: connect: no route to host
goroutine 1 [running]:
k8s.io/klog/v2.stacks(0xc00000e001, 0xc000188280, 0xd9, 0x24b)
	/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:1026 +0xb9
k8s.io/klog/v2.(*loggingT).output(0x260bd40, 0xc000000003, 0x0, 0x0, 0xc00011afc0, 0x0, 0x1eec030, 0x7, 0x94, 0x0)
	/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:975 +0x1e5
k8s.io/klog/v2.(*loggingT).printf(0x260bd40, 0xc000000003, 0x0, 0x0, 0x0, 0x0, 0x199a80d, 0x1b, 0xc00011c980, 0x1, ...)
	/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:753 +0x19a
k8s.io/klog/v2.Fatalf(...)
	/go/pkg/mod/k8s.io/klog/v2@v2.9.0/klog.go:1514
main.main()
	/go/src/k8s.io/kube-state-metrics/main.go:148 +0xcd5

# when .log file not present but logs read from -errors-logs.log(pod in err state)
# when -c is not present, kubectl will assign default container
➜ k logs backend-65746cc8dc-chdlr
failed to get log stream: container "app" in pod "backend-65746cc8dc-chdlr" is waiting to start: CreateContainerConfigError

# with a valid query, when both files not present, let the users know that no files to read from SB rather than kubectl client error
# so, sbctl users can look into bundle directly for other troubleshooting steps
➜ k logs kotsadm-postgres-0
log files not found in support-bundle.
/Users/sokke/Downloads/0/celonis-support-bundle-2022-02-28T15_14_22/cluster-resources/pods/logs/default/kotsadm-postgres-0/kotsadm-postgres.log
/Users/sokke/Downloads/0/celonis-support-bundle-2022-02-28T15_14_22/cluster-resources/pods/logs/default/kotsadm-postgres-0/kotsadm-postgres-logs-errors.log%

# query with a invalid container name[kubectl throws err]
➜  k logs -n monitoring kube-state-metrics-f97897479-cf57l -c invalid-container

error: container invalid-container is not valid for pod kube-state-metrics-f97897479-cf57l

# fetch previous logs
➜ k logs -n kurl ekc-operator-69c5f549fb-r4f54 -p
Error: initialize webhook server: get priorityclass node-critical: Get "https://***HIDDEN***:443/apis/scheduling.k8s.io/v1/priorityclasses/node-critical": dial tcp ***HIDDEN***:443: connect: no route to host
Usage:
  ekco operator [flags]

Flags:
      --ceph_block_pool string                  Name of CephBlockPool to manage if maintain_rook_storage_nodes is enabled (default "replicapool")
      --ceph_filesystem string
```