### PR TITLE
Convert core/v1 service list to table format for the get command

### DIFF
--- a/cli/serve.go
+++ b/cli/serve.go
@@ -111,8 +111,8 @@ func ServeCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().String("support-bundle-location", "", "path to support bundle archive, directory, or URL")
-	cmd.Flags().String("token", "", "API token for authentication when fetching on-line bundles")
+	cmd.Flags().StringP("support-bundle-location", "s", "", "path to support bundle archive, directory, or URL")
+	cmd.Flags().StringP("token", "t", "", "API token for authentication when fetching on-line bundles")
 	return cmd
 }
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -312,7 +312,7 @@ func (h handler) getAPIV1ClusterResources(w http.ResponseWriter, r *http.Request
 	if asTable {
 		table, err := toTable(result)
 		if err != nil {
-			log.Println("could not convert to table", err)
+			log.Println("could not convert to table:", err)
 		} else {
 			result = table
 		}
@@ -416,7 +416,7 @@ func (h handler) getAPIV1NamespaceResources(w http.ResponseWriter, r *http.Reque
 	if asTable {
 		table, err := toTable(decoded)
 		if err != nil {
-			log.Println("could not convert to table", err)
+			log.Println("could not convert to table:", err)
 		} else {
 			decoded = table
 		}
@@ -773,7 +773,7 @@ func (h handler) getAPIsClusterResources(w http.ResponseWriter, r *http.Request)
 	if asTable {
 		table, err := toTable(result)
 		if err != nil {
-			log.Println("could not convert to table", err)
+			log.Println("could not convert to table:", err)
 		} else {
 			result = table
 		}
@@ -854,7 +854,7 @@ func (h handler) getAPIsNamespaceResources(w http.ResponseWriter, r *http.Reques
 	if asTable {
 		table, err := toTable(decoded)
 		if err != nil {
-			log.Println("could not convert to table", err)
+			log.Println("could not convert to table:", err)
 		} else {
 			decoded = table
 		}
@@ -1144,6 +1144,20 @@ func toTable(object runtime.Object) (runtime.Object, error) {
 		err := apicorev1.Convert_v1_Node_To_core_Node(o, converted, nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to convert node")
+		}
+		object = converted
+	case *corev1.ServiceList:
+		converted := &apicore.ServiceList{}
+		err := apicorev1.Convert_v1_ServiceList_To_core_ServiceList(o, converted, nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert service list")
+		}
+		object = converted
+	case *corev1.Service:
+		converted := &apicore.Service{}
+		err := apicorev1.Convert_v1_Service_To_core_Service(o, converted, nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert service")
 		}
 		object = converted
 	case *batchv1beta1.CronJobList:


### PR DESCRIPTION
Before:

```
$ kubectl get svc -A
NAMESPACE        NAME                                 AGE
default          kotsadm                              6d3h
default          kotsadm-postgres                     6d3h
default          kubernetes                           6d3h
default          kurl-proxy-kotsadm                   6d3h
kube-system      kube-dns                             6d3h
kube-system      prometheus-coredns                   6d3h
kube-system      prometheus-kube-controller-manager   6d3h
kube-system      prometheus-kube-etcd                 6d3h
kube-system      prometheus-kube-proxy                6d3h
kube-system      prometheus-kube-scheduler            6d3h
kube-system      prometheus-kubelet                   6d3h
kurl             registry                             6d3h
```

After:
```
$ kubectl get svc -A
NAMESPACE        NAME                                 TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)                        AGE
default          kotsadm                              ClusterIP   ***HIDDEN***   <none>        3000/TCP                       6d3h
default          kotsadm-postgres                     ClusterIP   ***HIDDEN***   <none>        5432/TCP                       6d3h
default          kubernetes                           ClusterIP   ***HIDDEN***   <none>        443/TCP                        6d3h
default          kurl-proxy-kotsadm                   NodePort    ***HIDDEN***   <none>        8800:8800/TCP                  6d3h
kube-system      kube-dns                             ClusterIP   ***HIDDEN***   <none>        53/UDP,53/TCP,9153/TCP         6d3h
kube-system      prometheus-coredns                   ClusterIP   None           <none>        9153/TCP                       6d3h
kube-system      prometheus-kube-controller-manager   ClusterIP   None           <none>        10252/TCP                      6d3h
kube-system      prometheus-kube-etcd                 ClusterIP   None           <none>        2379/TCP                       6d3h
kube-system      prometheus-kube-proxy                ClusterIP   None           <none>        10249/TCP                      6d3h
kube-system      prometheus-kube-scheduler            ClusterIP   None           <none>        10251/TCP                      6d3h
kube-system      prometheus-kubelet                   ClusterIP   None           <none>        10250/TCP,10255/TCP,4194/TCP   6d3h
kurl             registry                             ClusterIP   ***HIDDEN***   <none>        443/TCP                        6d3h
```