### PR TITLE
Initial support for label selectors

### DIFF
--- a/pkg/k8s/objects.go
+++ b/pkg/k8s/objects.go
@@ -1,0 +1,61 @@
+package k8s
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func GetEmptyEventList() *corev1.EventList {
+	r := &corev1.EventList{
+		Items: []corev1.Event{},
+	}
+	r.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+		Version: "v1",
+		Kind:    "EventList",
+	})
+	return r
+}
+
+func GetEmptyPodList() *corev1.PodList {
+	r := &corev1.PodList{
+		Items: []corev1.Pod{},
+	}
+	r.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+		Version: "v1",
+		Kind:    "PodList",
+	})
+	return r
+}
+
+func GetEmptyLimitRangeList() *corev1.LimitRangeList {
+	r := &corev1.LimitRangeList{
+		Items: []corev1.LimitRange{},
+	}
+	r.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+		Version: "v1",
+		Kind:    "LimitRangeList",
+	})
+	return r
+}
+
+func GetEmptyServiceList() *corev1.ServiceList {
+	r := &corev1.ServiceList{
+		Items: []corev1.Service{},
+	}
+	r.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+		Version: "v1",
+		Kind:    "ServiceList",
+	})
+	return r
+}
+
+func GetEmptyPersistentVolumeClaimList() *corev1.PersistentVolumeClaimList {
+	r := &corev1.PersistentVolumeClaimList{
+		Items: []corev1.PersistentVolumeClaim{},
+	}
+	r.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{
+		Version: "v1",
+		Kind:    "PersistentVolumeClaimList",
+	})
+	return r
+}


### PR DESCRIPTION
```
$ kubectl get pods -n velero -l name=restic
NAME           READY   STATUS    RESTARTS   AGE
restic-5dkdh   1/1     Running   0          2d18h
restic-cccz9   1/1     Running   0          2d18h
restic-f8vwl   1/1     Running   0          2d18h
```
```
$ kubectl get pods -A -l name=restic
NAMESPACE   NAME           READY   STATUS    RESTARTS   AGE
velero      restic-5dkdh   1/1     Running   0          2d18h
velero      restic-cccz9   1/1     Running   0          2d18h
velero      restic-f8vwl   1/1     Running   0          2d18h
```