### PR TITLE
Small readme readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 ### How to install:
 
 Download the release binary and untar it to the /usr/bin/ directory:
-`wget https://github.com/replicatedhq/sbctl/releases/download/{{ VERSION_NUMBER_GOES_HERE }}/sbctl_darwin_amd64.tar.gz`
-`tar -xzf sbctl_darwin_amd64.tar.gz -C /usr/bin/`
-
+```
+$ wget https://github.com/replicatedhq/sbctl/releases/download/{{ VERSION_NUMBER_GOES_HERE }}/sbctl_darwin_amd64.tar.gz
+$ tar -xzf sbctl_darwin_amd64.tar.gz -C /usr/bin/
+```
 Restart your shell and proceed to "How to Use"
 
 ### How to Use:


### PR DESCRIPTION
I think this syntax is a little clearer when rendered. In the target branch, the two command get squished together onto one line. I think the code snippet is also easier to copy+paste from.