### PR TITLE
Update shell.go

### DIFF
--- a/cli/shell.go
+++ b/cli/shell.go
@@ -117,7 +117,7 @@ func ShellCmd() *cobra.Command {
 
 			shellExec := exec.Command(shellCmd)
 			shellExec.Env = os.Environ()
-			fmt.Printf("Starting new shell with KUBECONFIG Ctl-D when done to end the shell and sbctl server\n")
+			fmt.Printf("Starting new shell with KUBECONFIG. Press Ctl-D when done to end the shell and the sbctl server\n")
 			shellPty, err := pty.Start(shellExec)
 
 			// Handle pty size.


### PR DESCRIPTION
Make the feedback after starting SBCTL a bit more readable. So changing `Starting new shell with KUBECONFIG Ctl-D when done to end the shell and sbctl server` to `Starting new shell with KUBECONFIG. Press Ctl-D when done to end the shell and the sbctl server`.