### PR TITLE
Fix hanging on some support bundles

### DIFF
--- a/pkg/sbctl/support-bundle.go
+++ b/pkg/sbctl/support-bundle.go
@@ -81,7 +81,11 @@ func FindClusterData(bundlePath string) (ClusterData, error) {
 
 		if info.IsDir() {
 			if info.Name() == "cluster-resources" {
-				result.ClusterResourcesDir = path
+				// Support bundle can have multiple cluster-resources directories.
+				// We want the one at the root, so find the file with the shortest name
+				if result.ClusterResourcesDir == "" || len(path) < len(result.ClusterResourcesDir) {
+					result.ClusterResourcesDir = path
+				}
 			}
 		} else if info.Name() == "cluster_version.json" {
 			result.ClusterInfoFile = path


### PR DESCRIPTION
1. Fixes hanging cluster resources path, which was causing sbctl to hang because server was never  started
2. Adds timeout to handle cases where server does not start
   ```
    $ sbctl shell -s "support-bundle-2022-11-30T18_39_52"
    API server logs will be written to /var/folders/g2/05ngff7d71gds3_kl24gs0f80000gn/T/sbctl-server-logs-2827922800
    Error: failed to create api server: timeout waiting for server to start
   ```