### PR TITLE
README improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
 # Command line tool for examining K8s resources in Troubleshoot's support bundles
 
-### How to install:
+### How to install (Mac):
 
-Download the release binary and untar it to a directory in your `PATH`:
+Download the release binary and untar it to a directory in your `PATH` (you'll need to enter your `sudo` password for the last `mv`):
 
 #### Intel CPU / `amd64`
 
 ```
-wget https://github.com/replicatedhq/sbctl/releases/latest/download/sbctl_darwin_amd64.tar.gz
-tar -xzf sbctl_darwin_amd64.tar.gz -C /usr/local/bin/
+curl -LO https://github.com/replicatedhq/sbctl/releases/latest/download/sbctl_darwin_amd64.tar.gz
+tar -xzf sbctl_darwin_amd64.tar.gz -C /tmp sbctl
+rm -f sbctl_darwin_amd64.tar.gz
+sudo mv /tmp/sbctl /usr/local/bin/
 ```
 
 #### Apple M1 CPU / `arm64`
 
 ```
-wget https://github.com/replicatedhq/sbctl/releases/latest/download/sbctl_darwin_arm64.tar.gz
-tar -xzf sbctl_darwin_arm64.tar.gz -C /usr/local/bin/
+curl -LO https://github.com/replicatedhq/sbctl/releases/latest/download/sbctl_darwin_arm64.tar.gz
+tar -xzf sbctl_darwin_arm64.tar.gz -C /tmp sbctl
+rm -f sbctl_darwin_arm64.tar.gz
+sudo mv /tmp/sbctl /usr/local/bin/
 ```
 
 Restart your shell and proceed to "How to Use".

--- a/README.md
+++ b/README.md
@@ -3,10 +3,21 @@
 ### How to install:
 
 Download the release binary and untar it to a directory in your `PATH`:
+
+#### Intel CPU / `amd64`
+
 ```
 wget https://github.com/replicatedhq/sbctl/releases/latest/download/sbctl_darwin_amd64.tar.gz
 tar -xzf sbctl_darwin_amd64.tar.gz -C /usr/local/bin/
 ```
+
+#### Apple M1 CPU / `arm64`
+
+```
+wget https://github.com/replicatedhq/sbctl/releases/latest/download/sbctl_darwin_arm64.tar.gz
+tar -xzf sbctl_darwin_arm64.tar.gz -C /usr/local/bin/
+```
+
 Restart your shell and proceed to "How to Use".
 
 ### How to Use:


### PR DESCRIPTION
- added M1 Mac vs Intel Mac install steps
  - I wanted to try use a single unified command with `uname -m` but since an Intel returns `x86_64` and not `amd64` calling that out of scope for now (would need to translate, or write a bash script snippet or something etc)

- changed from `wget` to `curl`, as `wget` isn't installed on MacOS Ventura by default (and possibly older MacOS versions too?)

- ensure the `README.md` file doesn't get in the way of the binary extract, and ensure it handles `sudo` properly to put `sbctl` into `/usr/local/bin`

----------------------------

![image](https://user-images.githubusercontent.com/916201/210480001-210b0b73-d4e9-47f6-a57b-85e5bd54cb84.png)
