### PR TITLE
Suppliment bundle location with positional arg

### DIFF
--- a/cli/serve.go
+++ b/cli/serve.go
@@ -23,6 +23,7 @@ func ServeCmd() *cobra.Command {
 		Use:           "serve",
 		Short:         "Start API server",
 		Long:          `Start API server`,
+		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -50,6 +51,9 @@ func ServeCmd() *cobra.Command {
 
 			// This only works with generated config, so let's make sure we don't mess up user's real files.
 			bundleLocation := v.GetString("support-bundle-location")
+			if len(args) > 0 && args[0] != "" {
+				bundleLocation = args[0]
+			}
 			if bundleLocation == "" {
 				return errors.New("support-bundle-location is required")
 			}

--- a/cli/shell.go
+++ b/cli/shell.go
@@ -24,6 +24,7 @@ func ShellCmd() *cobra.Command {
 		Use:           "shell",
 		Short:         "Start interractive shell",
 		Long:          `Start interractive shell`,
+		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
@@ -61,6 +62,9 @@ func ShellCmd() *cobra.Command {
 
 			// This only works with generated config, so let's make sure we don't mess up user's real files.
 			bundleLocation := v.GetString("support-bundle-location")
+			if len(args) > 0 && args[0] != "" {
+				bundleLocation = args[0]
+			}
 			if bundleLocation == "" {
 				return errors.New("support-bundle-location is required")
 			}


### PR DESCRIPTION
Left the --support-bundle-location // -c flag in place to not dusrupt existing use, but it's no longer mandatory. sbctl subcommands `serve` and `shell` will take the first positional argument as the bundle location.

fixes #136
fixes #59 