### PR TITLE
Print extracted bundle path

### DIFF
--- a/cli/serve.go
+++ b/cli/serve.go
@@ -71,6 +71,7 @@ func ServeCmd() *cobra.Command {
 				if err != nil {
 					return errors.Wrap(err, "failed to stat input path")
 				}
+				fmt.Printf("Bundle extracted to %s\n", dir)
 				bundleDir = dir
 				deleteBundleDir = true
 			} else {

--- a/cli/shell.go
+++ b/cli/shell.go
@@ -82,6 +82,7 @@ func ShellCmd() *cobra.Command {
 				if err != nil {
 					return errors.Wrap(err, "failed to stat input path")
 				}
+				fmt.Printf("Bundle extracted to %s\n", dir)
 				bundleDir = dir
 				deleteBundleDir = true
 			} else {


### PR DESCRIPTION
Users can open the dir to the extracted bundle if they want.

<img width="1143" alt="image" src="https://github.com/user-attachments/assets/ea5ad47f-4abc-464d-aadb-75c54e890665">
