### PR TITLE
Add network policies support

### DIFF
--- a/pkg/util/support-bundle.go
+++ b/pkg/util/support-bundle.go
@@ -9,6 +9,7 @@ var (
 		"ingresses":                 "ingress",
 		"customresourcedefinitions": "custom-resource-definitions",
 		"clusterrolebindings":       "clusterRoleBindings",
+		"networkpolicies":           "network-policy",
 	}
 )
 


### PR DESCRIPTION
Allow sbctl to serve `kubectl get networkpolicies.networking.k8s.io`

Demo: https://asciinema.org/a/TL5ImInhK9JVkpWKGyElhpnFe