### PR TITLE
fix(shell): use syscall.stdin instead of os.stdin.fd()

### DIFF
--- a/cli/shell.go
+++ b/cli/shell.go
@@ -19,11 +19,6 @@ import (
 	"golang.org/x/term"
 )
 
-// Convert uintptr to int safely
-func fdToInt(fd uintptr) int {
-	return int(fd)
-}
-
 func ShellCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "shell",
@@ -149,12 +144,12 @@ func ShellCmd() *cobra.Command {
 			defer func() { signal.Stop(ch); close(ch) }()
 
 			// Set stdin to raw mode.
-			oldState, err := term.MakeRaw(fdToInt(os.Stdin.Fd()))
+			oldState, err := term.MakeRaw(syscall.Stdin)
 			if err != nil {
 				panic(err)
 			}
 			defer func() {
-				_ = term.Restore(fdToInt(os.Stdin.Fd()), oldState)
+				_ = term.Restore(syscall.Stdin, oldState)
 				fmt.Printf("sbctl shell exited\n")
 			}()
 

--- a/cli/shell.go
+++ b/cli/shell.go
@@ -19,6 +19,11 @@ import (
 	"golang.org/x/term"
 )
 
+// Convert uintptr to int safely
+func fdToInt(fd uintptr) int {
+	return int(fd)
+}
+
 func ShellCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "shell",
@@ -144,12 +149,12 @@ func ShellCmd() *cobra.Command {
 			defer func() { signal.Stop(ch); close(ch) }()
 
 			// Set stdin to raw mode.
-			oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
+			oldState, err := term.MakeRaw(fdToInt(os.Stdin.Fd()))
 			if err != nil {
 				panic(err)
 			}
 			defer func() {
-				_ = term.Restore(int(os.Stdin.Fd()), oldState)
+				_ = term.Restore(fdToInt(os.Stdin.Fd()), oldState)
 				fmt.Printf("sbctl shell exited\n")
 			}()
 


### PR DESCRIPTION
- solve the make lint error `fail with Potential integer overflow when converting between integer types`

syscall.Stdin is  for a low-level operation  and return int 
os.Stdin is high-level Read method to read input normally. but os.Stdin.Fd() return uintptr which need to be convert to int
