### PR TITLE
feat: download and extract bundles that do not have cluster resources using shell subcommand

### DIFF
--- a/cli/download.go
+++ b/cli/download.go
@@ -41,38 +41,16 @@ func DownloadCmd() *cobra.Command {
 			}
 
 			fmt.Println("Downloading bundle...")
-			if v.GetBool("shell") {
-				err := downloadBundleAndShell(bundleLocation, token)
-				if err != nil {
-					return err
-				}
-			} else {
-				file, err := downloadBundleToDisk(bundleLocation, token)
-				if err != nil {
-					return err
-				}
-				fmt.Println(file)
+			file, err := downloadBundleToDisk(bundleLocation, token)
+			if err != nil {
+				return err
 			}
-
+			fmt.Println(file)
 			return nil
 		},
 	}
 
-	cmd.Flags().Bool("shell", false, "Start shell in downloaded and extracted bundle directory. Delete the directory when shell exits.")
-
 	return cmd
-}
-
-func downloadBundleAndShell(bundleLocation, token string) error {
-	bundleDir, err := downloadAndExtractBundle(bundleLocation, token)
-	if err != nil {
-		return errors.Wrap(err, "failed to stat input path")
-	}
-	defer os.RemoveAll(bundleDir)
-	fmt.Printf("Bundle extracted to %s\n", bundleDir)
-
-	fmt.Printf("Starting new shell in downloaded bunde. Press Ctl-D when done to end the shell and the sbctl server\n")
-	return startShellAndWait(fmt.Sprintf("cd %s", bundleDir))
 }
 
 func downloadBundleToDisk(bundleUrl string, token string) (string, error) {

--- a/cli/download.go
+++ b/cli/download.go
@@ -17,9 +17,12 @@ import (
 func DownloadCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "download",
-		Short: "Download bundle from url",
-		Long:  "Download bundle from url",
+		Short: "Download bundle from Vendor Portal url",
+		Long:  "Download bundle from Vendor Portal url",
 		Args:  cobra.MaximumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			return viper.BindPFlags(cmd.Flags())
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := viper.GetViper()
 
@@ -38,34 +41,75 @@ func DownloadCmd() *cobra.Command {
 			}
 
 			fmt.Println("Downloading bundle...")
-
-			file, err := downloadBundleToDisk(bundleLocation, token)
-			if err != nil {
-				return err
+			if v.GetBool("shell") {
+				err := downloadBundleAndShell(bundleLocation, token)
+				if err != nil {
+					return err
+				}
+			} else {
+				file, err := downloadBundleToDisk(bundleLocation, token)
+				if err != nil {
+					return err
+				}
+				fmt.Println(file)
 			}
-			fmt.Println(file)
 
 			return nil
 		},
 	}
 
+	cmd.Flags().Bool("shell", false, "Start shell in downloaded and extracted bundle directory. Delete the directory when shell exits.")
+
 	return cmd
 }
 
+func downloadBundleAndShell(bundleLocation, token string) error {
+	bundleDir, err := downloadAndExtractBundle(bundleLocation, token)
+	if err != nil {
+		return errors.Wrap(err, "failed to stat input path")
+	}
+	defer os.RemoveAll(bundleDir)
+	fmt.Printf("Bundle extracted to %s\n", bundleDir)
+
+	fmt.Printf("Starting new shell in downloaded bunde. Press Ctl-D when done to end the shell and the sbctl server\n")
+	return startShellAndWait(fmt.Sprintf("cd %s", bundleDir))
+}
+
 func downloadBundleToDisk(bundleUrl string, token string) (string, error) {
+	body, err := downloadBundleFromVendorPortal(bundleUrl, token)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to download bundle")
+	}
+	defer body.Close()
+
+	sbFile, err := os.Create("support-bundle.tgz")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create file")
+	}
+	defer sbFile.Close()
+
+	_, err = io.Copy(sbFile, body)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to copy bundle to file")
+	}
+
+	return sbFile.Name(), nil
+}
+
+func downloadBundleFromVendorPortal(bundleUrl, token string) (io.ReadCloser, error) {
 	parsedUrl, err := url.Parse(bundleUrl)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to parse url")
+		return nil, errors.Wrap(err, "failed to parse url")
 	}
 
 	_, slug := path.Split(parsedUrl.Path)
 	if slug == "" {
-		return "", errors.New("failed to extract slug from URL")
+		return nil, errors.New("failed to extract slug from URL")
 	}
 	sbEndpoint := fmt.Sprintf("https://api.replicated.com/vendor/v3/supportbundle/%s", slug)
 	req, err := http.NewRequest("GET", sbEndpoint, nil)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to create HTTP request")
+		return nil, errors.Wrap(err, "failed to create HTTP request")
 	}
 
 	req.Header.Add("Authorization", token)
@@ -73,17 +117,17 @@ func downloadBundleToDisk(bundleUrl string, token string) (string, error) {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to execute request")
+		return nil, errors.Wrap(err, "failed to execute request")
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to read GQL response")
+		return nil, errors.Wrap(err, "failed to read GQL response")
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", errors.Errorf("unexpected status code: %v", resp.StatusCode)
+		return nil, errors.Errorf("unexpected status code: %v", resp.StatusCode)
 	}
 
 	bundleObj := struct {
@@ -93,29 +137,17 @@ func downloadBundleToDisk(bundleUrl string, token string) (string, error) {
 	}{}
 	err = json.Unmarshal(body, &bundleObj)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to unmarshal response: %s", body)
+		return nil, errors.Wrapf(err, "failed to unmarshal response: %s", body)
 	}
 
 	resp, err = http.Get(bundleObj.Bundle.SignedUri)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to execute signed URL request")
+		return nil, errors.Wrap(err, "failed to execute signed URL request")
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return "", errors.Errorf("unexpected status code: %v", resp.StatusCode)
+		return nil, errors.Errorf("unexpected status code: %v", resp.StatusCode)
 	}
 
-	sbFile, err := os.Create("support-bundle.tgz")
-	if err != nil {
-		return "", errors.Wrap(err, "failed to create file")
-	}
-	defer sbFile.Close()
-
-	_, err = io.Copy(sbFile, resp.Body)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to copy bundle to file")
-	}
-
-	return sbFile.Name(), nil
+	return resp.Body, nil
 }

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -96,6 +96,12 @@ func ServeCmd() *cobra.Command {
 				return errors.Wrap(err, "failed to find cluster data")
 			}
 
+			// If we did not find cluster data, just don't start the API server
+			if clusterData.ClusterResourcesDir == "" {
+				fmt.Println("No cluster resources found in bundle")
+				return nil
+			}
+
 			kubeConfig, err = api.StartAPIServer(clusterData, os.Stderr)
 			if err != nil {
 				return errors.Wrap(err, "failed to create api server")

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -1,14 +1,10 @@
 package cli
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
-	"net/url"
 	"os"
 	"os/signal"
-	"path"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -123,58 +119,11 @@ func ServeCmd() *cobra.Command {
 }
 
 func downloadAndExtractBundle(bundleUrl string, token string) (string, error) {
-	parsedUrl, err := url.Parse(bundleUrl)
+	body, err := downloadBundleFromVendorPortal(bundleUrl, token)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to parse url")
+		return "", errors.Wrap(err, "failed to download bundle")
 	}
-
-	_, slug := path.Split(parsedUrl.Path)
-	if slug == "" {
-		return "", errors.New("failed to extract slug from URL")
-	}
-	sbEndpoint := fmt.Sprintf("https://api.replicated.com/vendor/v3/supportbundle/%s", slug)
-	req, err := http.NewRequest("GET", sbEndpoint, nil)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to create HTTP request")
-	}
-
-	req.Header.Add("Authorization", token)
-	req.Header.Add("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to execute request")
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to read GQL response")
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return "", errors.Errorf("unexpected status code: %v", resp.StatusCode)
-	}
-
-	bundleObj := struct {
-		Bundle struct {
-			SignedUri string `json:"signedUri"`
-		} `json:"bundle"`
-	}{}
-	err = json.Unmarshal(body, &bundleObj)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to unmarshal response: %s", body)
-	}
-
-	resp, err = http.Get(bundleObj.Bundle.SignedUri)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to execute signed URL request")
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", errors.Errorf("unexpected status code: %v", resp.StatusCode)
-	}
+	defer body.Close()
 
 	tmpFile, err := os.CreateTemp("", "sbctl-bundle-")
 	if err != nil {
@@ -182,7 +131,7 @@ func downloadAndExtractBundle(bundleUrl string, token string) (string, error) {
 	}
 	defer tmpFile.Close()
 
-	_, err = io.Copy(tmpFile, resp.Body)
+	_, err = io.Copy(tmpFile, body)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to copy bundle to tmp file")
 	}

--- a/cli/shell.go
+++ b/cli/shell.go
@@ -144,7 +144,6 @@ func startShellAndWait(cmds ...string) error {
 
 	shellExec := exec.Command(shellCmd)
 	shellExec.Env = os.Environ()
-	// fmt.Printf("Starting new shell with KUBECONFIG. Press Ctl-D when done to end the shell and the sbctl server\n")
 	shellPty, err := pty.Start(shellExec)
 	if err != nil {
 		return errors.Wrap(err, "failed to start shell")


### PR DESCRIPTION
Allow `shell` subcommand to download and extract support bundles that do not have cluster resources e.g host support bundles. An API server will not be started in such cases.

- Download bundle from Vendor Portal
- Unarchive bundle to a temp directory in the `TMPDIR` directory
- Open a new shell and `CD` into the extracted bundle temp directory
- Delete the temp directory after exiting from the shell

Demo: https://asciinema.org/a/EbCP6S78O1lv3kajkHDCSvp9x

Fixes: https://github.com/replicatedhq/sbctl/issues/71
