### PR TITLE
fix(dependabot): fix auto merge fail

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       - "dependencies"
       - "go"
       - "type::chore"
+      - "type::security"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 20
@@ -28,5 +29,6 @@ updates:
       - "dependencies"
       - "github-actions"
       - "type::chore"
+      - "type::security"
     schedule:
       interval: "weekly"

--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.23"
 
       - name: setup env
         run: |
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.23"
 
       - name: setup env
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.23"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/replicatedhq/sbctl
 
-go 1.22.0
-
-toolchain go1.22.2
+go 1.23.4
 
 require (
 	github.com/antzucaro/matchr v0.0.0-20210222213004-b04723ef80f0


### PR DESCRIPTION
- fix missing `type::security` for dependbot
- upgrade go build version to 1.23