### PR TITLE
Add version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,12 @@ BUILDTAGS = "netgo containers_image_ostree_stub exclude_graphdriver_devicemapper
 BUILDFLAGS = -tags ${BUILDTAGS} -installsuffix netgo
 BUILDPATHS = ./pkg/... ./cli/... ./tests/...
 
+# Set version from git tag, or use "dev" if not a tagged commit
+VERSION ?= $(shell git describe --tags 2>/dev/null || echo "dev")
+
 .PHONY: build
 build: mod-tidy fmt vet
-	go build -o bin/sbctl sbctl.go
+	go build -o bin/sbctl -ldflags "-X github.com/replicatedhq/sbctl/cli.Version=${VERSION}" sbctl.go
 
 .PHONY: mod-tidy
 mod-tidy:
@@ -32,7 +35,7 @@ vet:
 # Compile and install sbctl locally in you GOBIN path
 .PHONY: install
 install: build
-	go install ${BUILDFLAGS} sbctl.go
+	go install ${BUILDFLAGS} -ldflags "-X github.com/replicatedhq/sbctl/cli.Version=${VERSION}" sbctl.go
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ Restart your shell and proceed to "How to Use".
 ```
 sbctl version
 ```
-Displays the version of sbctl and the Go compiler version used to build the binary.
+Displays the version information in the format:
+```
+sbctl version [version-number]
+go version [go-version-number]
+```
 
 #### Start server in foreground
 Start the local API server using a support bundle and then run the `export` command that comes up to make kubectl target your support bundles API server

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Restart your shell and proceed to "How to Use".
 
 ### How to Use:
 
+#### Check the version
+```
+sbctl version
+```
+Displays the version of sbctl and the Go compiler version used to build the binary.
+
 #### Start server in foreground
 Start the local API server using a support bundle and then run the `export` command that comes up to make kubectl target your support bundles API server
 

--- a/cli/root.go
+++ b/cli/root.go
@@ -27,6 +27,7 @@ func RootCmd() *cobra.Command {
 	cmd.AddCommand(ServeCmd())
 	cmd.AddCommand(ShellCmd())
 	cmd.AddCommand(DownloadCmd())
+	cmd.AddCommand(VersionCmd())
 
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 

--- a/cli/version.go
+++ b/cli/version.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+// Version represents the version of sbctl
+var Version string = "dev"
+
+// GoVersion represents the Go version used to build the binary
+var GoVersion string = runtime.Version()
+
+// VersionCmd returns a command that displays the version of sbctl
+func VersionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print the version of sbctl",
+		Long:  `Print the version of sbctl`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("%s\n%s\n", Version, GoVersion)
+		},
+	}
+
+	return cmd
+}

--- a/cli/version.go
+++ b/cli/version.go
@@ -20,7 +20,7 @@ func VersionCmd() *cobra.Command {
 		Short: "Print the version of sbctl",
 		Long:  `Print the version of sbctl`,
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("%s\n%s\n", Version, GoVersion)
+			fmt.Printf("sbctl version %s\ngo version %s\n", Version, GoVersion)
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Adds version subcommand to display sbctl version and Go compiler version
- Updates Makefile to set version during build time
- Updates README with version command documentation

## Test plan
1. Build the binary with \go mod tidy
go fmt ./pkg/... ./cli/... ./tests/...
go vet -tags "netgo containers_image_ostree_stub exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_openpgp" -installsuffix netgo ./pkg/... ./cli/... ./tests/...
go build -o bin/sbctl -ldflags "-X github.com/replicatedhq/sbctl/cli.Version=v0.17.1-33-gadd33d0" sbctl.go
2. Run \v0.17.1-33-gadd33d0
go1.24.2 to verify it displays both the sbctl version and Go compiler version