### PR TITLE
feat: fall back to Replicated CLI config for auth tokens

### DIFF
--- a/cli/download.go
+++ b/cli/download.go
@@ -35,9 +35,9 @@ func DownloadCmd() *cobra.Command {
 				return errors.New("support-bundle-location is required")
 			}
 
-			token := v.GetString("token")
-			if token == "" {
-				return errors.New("token is required when downloading bundle")
+			token, err := resolveToken(v)
+			if err != nil {
+				return err
 			}
 
 			fmt.Println("Downloading bundle...")

--- a/cli/root.go
+++ b/cli/root.go
@@ -24,6 +24,8 @@ func RootCmd() *cobra.Command {
 		viper.AutomaticEnv()
 	})
 
+	cmd.PersistentFlags().String("profile", "", "Replicated CLI profile to use for authentication (defaults to profile set in ~/.replicated/config.yaml)")
+
 	cmd.AddCommand(ServeCmd())
 	cmd.AddCommand(ShellCmd())
 	cmd.AddCommand(DownloadCmd())

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -56,9 +56,9 @@ func ServeCmd() *cobra.Command {
 			}
 
 			if strings.HasPrefix(bundleLocation, "http") {
-				token := v.GetString("token")
-				if token == "" {
-					return errors.New("token is required when downloading bundle")
+				token, err := resolveToken(v)
+				if err != nil {
+					return err
 				}
 
 				fmt.Printf("Downloading bundle\n")

--- a/cli/shell.go
+++ b/cli/shell.go
@@ -81,9 +81,9 @@ func ShellCmd() *cobra.Command {
 			}
 
 			if strings.HasPrefix(bundleLocation, "http") {
-				token := v.GetString("token")
-				if token == "" {
-					return errors.New("token is required when downloading bundle")
+				token, err := resolveToken(v)
+				if err != nil {
+					return err
 				}
 
 				fmt.Printf("Downloading bundle\n")

--- a/cli/token.go
+++ b/cli/token.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/replicatedhq/sbctl/pkg/config"
+	"github.com/spf13/viper"
+)
+
+// resolveToken returns the API token by checking, in order:
+// 1. --token flag / SBCTL_TOKEN env var
+// 2. ~/.replicated/config.yaml (using --profile flag or defaultProfile)
+func resolveToken(v *viper.Viper) (string, error) {
+	if token := v.GetString("token"); token != "" {
+		return token, nil
+	}
+
+	profileName := v.GetString("profile")
+	token, err := config.GetTokenFromReplicatedConfig(profileName)
+	if err != nil {
+		if profileName != "" {
+			return "", fmt.Errorf("token not provided and failed to read profile %q from replicated config: %w", profileName, err)
+		}
+		return "", fmt.Errorf("token is required when downloading bundle (set --token, SBCTL_TOKEN, or configure ~/.replicated/config.yaml)")
+	}
+
+	return token, nil
+}

--- a/cli/token.go
+++ b/cli/token.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/replicatedhq/sbctl/pkg/config"
 	"github.com/spf13/viper"
@@ -13,6 +14,11 @@ import (
 func resolveToken(v *viper.Viper) (string, error) {
 	if token := v.GetString("token"); token != "" {
 		return token, nil
+	}
+
+	replToken := os.Getenv("REPLICATED_API_TOKEN")
+	if replToken != "" {
+		return replToken, nil
 	}
 
 	profileName := v.GetString("profile")

--- a/pkg/config/replicated.go
+++ b/pkg/config/replicated.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+)
+
+type ReplicatedConfig struct {
+	Profiles       map[string]Profile `yaml:"profiles"`
+	DefaultProfile string             `yaml:"defaultProfile"`
+}
+
+type Profile struct {
+	APIToken string `yaml:"apiToken"`
+}
+
+func ReplicatedConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".replicated", "config.yaml")
+}
+
+// GetTokenFromReplicatedConfig reads the API token from the Replicated CLI
+// config file at ~/.replicated/config.yaml. If profileName is empty, it uses
+// the defaultProfile from the config.
+func GetTokenFromReplicatedConfig(profileName string) (string, error) {
+	configPath := ReplicatedConfigPath()
+	if configPath == "" {
+		return "", errors.New("could not determine home directory")
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to read replicated config")
+	}
+
+	var cfg ReplicatedConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return "", errors.Wrap(err, "failed to parse replicated config")
+	}
+
+	if profileName == "" {
+		profileName = cfg.DefaultProfile
+	}
+	if profileName == "" {
+		return "", errors.New("no profile specified and no defaultProfile set in replicated config")
+	}
+
+	profile, ok := cfg.Profiles[profileName]
+	if !ok {
+		return "", errors.Errorf("profile %q not found in replicated config", profileName)
+	}
+
+	if profile.APIToken == "" {
+		return "", errors.Errorf("profile %q has no apiToken", profileName)
+	}
+
+	return profile.APIToken, nil
+}

--- a/pkg/config/replicated_test.go
+++ b/pkg/config/replicated_test.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetTokenFromReplicatedConfig(t *testing.T) {
+	// Create a temporary config file
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, ".replicated")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	configContent := `profiles:
+  prod:
+    apiToken: prod-token-123
+  staging:
+    apiToken: staging-token-456
+  empty:
+    apiToken: ""
+defaultProfile: prod
+`
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Override the config path for testing
+	origHome := os.Getenv("HOME")
+	t.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	tests := []struct {
+		name        string
+		profile     string
+		wantToken   string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:      "default profile",
+			profile:   "",
+			wantToken: "prod-token-123",
+		},
+		{
+			name:      "explicit profile",
+			profile:   "staging",
+			wantToken: "staging-token-456",
+		},
+		{
+			name:        "nonexistent profile",
+			profile:     "nonexistent",
+			wantErr:     true,
+			errContains: "not found",
+		},
+		{
+			name:        "empty token profile",
+			profile:     "empty",
+			wantErr:     true,
+			errContains: "no apiToken",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token, err := GetTokenFromReplicatedConfig(tt.profile)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errContains != "" && !contains(err.Error(), tt.errContains) {
+					t.Fatalf("error %q should contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if token != tt.wantToken {
+				t.Fatalf("got token %q, want %q", token, tt.wantToken)
+			}
+		})
+	}
+}
+
+func TestGetTokenFromReplicatedConfig_MissingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	_, err := GetTokenFromReplicatedConfig("")
+	if err == nil {
+		t.Fatal("expected error for missing config file")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- When `--token` / `SBCTL_TOKEN` is not set, sbctl now falls back to reading
  auth tokens from the Replicated CLI config at `~/.replicated/config.yaml`
- Adds a `--profile` global flag to select which profile to read the token from;
  defaults to `defaultProfile` in the config file
- Applies to all commands that download bundles: `download`, `serve`, and `shell`

## Test plan
- [x] Verify existing `--token` flag and `SBCTL_TOKEN` env var still take precedence
- [x] Verify token is read from `~/.replicated/config.yaml` default profile when no token is provided
- [x] Verify `--profile <name>` selects the correct profile
- [x] Verify clear error when profile doesn't exist or has no token
- [x] Verify clear error when config file is missing and no token is provided
- [x] Run `go test ./...`
