### PR TITLE
Add --log-file flag to shell command, default to ~/sbctl-server.log

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,3 +216,55 @@ troubleshoot-demo-003   Ready    <none>                 2d21h   v1.23.5
 bash-5.0$ exit
 exit
 ```
+
+## Authentication
+
+sbctl supports optional token-based authentication to secure kubectl commands connecting to the local API server.
+
+**Note:** Enabling authentication automatically enables HTTPS with self-signed certificates. This is required because kubectl refuses to send credentials over unencrypted HTTP connections.
+
+### Runtime Authentication
+
+Enable authentication at runtime using the `--enable-auth` flag:
+
+```bash
+sbctl serve --enable-auth ~/Downloads/support-bundle-2024-XX-XX
+
+Server is running
+
+Authentication is enabled
+
+export KUBECONFIG=/var/folders/.../T/local-kubeconfig-XXXXX
+```
+
+The generated token and TLS certificate are automatically included in the kubeconfig file, so kubectl commands will work seamlessly.
+
+### Compile-Time Authentication Enforcement
+
+For environments requiring mandatory authentication, build sbctl with the `auth_required` build tag:
+
+```bash
+go build -tags auth_required -o sbctl sbctl.go
+```
+
+When built with this tag, authentication is always enabled regardless of the `--enable-auth` flag.
+
+### Security Features
+
+- **HTTPS with TLS**: Self-signed certificates auto-generated for each session (24-hour validity)
+- **256-bit tokens**: Cryptographically secure random tokens using `crypto/rand`
+- **Bearer token standard**: Compatible with OAuth 2.0 conventions
+- **Constant-time comparison**: Prevents timing attacks during token validation
+- **Localhost-only**: Server binds to 127.0.0.1 for additional security
+- **All endpoints protected**: No exemptions - every API endpoint requires authentication
+
+### Authentication with Shell Mode
+
+The `shell` command also supports the `--enable-auth` flag:
+
+```bash
+sbctl shell --enable-auth ~/Downloads/support-bundle-2024-XX-XX
+
+Authentication is enabled
+Starting new shell with KUBECONFIG. Press Ctl-D when done to exit from the shell and stop sbctl server
+```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ export SBCTL_TOKEN=<token>
 Now launch the shell
 ```
 sbctl shell https://vendor.replicated.com/troubleshoot/analyze/2024-08-02@00:01
-API server logs will be written to /var/folders/19/bp6c9chj0sgcpcxmxxl69s040000gn/T/sbctl-server-logs-1413638036
+SBCTL logs will be written to ~/sbctl-server.log
 Downloading bundle
 Bundle extracted to /var/folders/19/bp6c9chj0sgcpcxmxxl69s040000gn/T/sbctl-2353785059
 Starting new shell with KUBECONFIG. Press Ctl-D when done to end the shell and the sbctl server
@@ -267,4 +267,21 @@ sbctl shell --enable-auth ~/Downloads/support-bundle-2024-XX-XX
 
 Authentication is enabled
 Starting new shell with KUBECONFIG. Press Ctl-D when done to exit from the shell and stop sbctl server
+```
+
+## Logging
+
+The `shell` command writes API server logs to `sbctl-server.log` in the user's home directory by default.
+
+Override the path with the `--log-file` flag:
+
+```bash
+sbctl shell --log-file /tmp/my-sbctl.log ~/Downloads/support-bundle-2024-XX-XX
+```
+
+Or set the `SBCTL_LOG_FILE` environment variable:
+
+```bash
+export SBCTL_LOG_FILE=/tmp/my-sbctl.log
+sbctl shell ~/Downloads/support-bundle-2024-XX-XX
 ```

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -102,14 +102,31 @@ func ServeCmd() *cobra.Command {
 				return nil
 			}
 
-			kubeConfig, err = api.StartAPIServer(clusterData, os.Stderr)
+			// Generate auth token and TLS certificate if required or enabled
+			var authToken string
+			var tlsCert *api.TLSCertificate
+			if api.AuthRequired || v.GetBool("enable-auth") {
+				authToken, err = api.GenerateToken()
+				if err != nil {
+					return errors.Wrap(err, "failed to generate auth token")
+				}
+
+				tlsCert, err = api.GenerateSelfSignedCert()
+				if err != nil {
+					return errors.Wrap(err, "failed to generate TLS certificate")
+				}
+			}
+
+			kubeConfig, err = api.StartAPIServer(clusterData, os.Stderr, authToken, tlsCert)
 			if err != nil {
 				return errors.Wrap(err, "failed to create api server")
-
 			}
 			defer os.RemoveAll(kubeConfig)
 
 			fmt.Printf("Server is running\n\n")
+			if authToken != "" {
+				fmt.Printf("Authentication is enabled\n\n")
+			}
 			fmt.Printf("export KUBECONFIG=%s\n\n", kubeConfig)
 
 			<-make(chan struct{})
@@ -120,6 +137,7 @@ func ServeCmd() *cobra.Command {
 
 	cmd.Flags().StringP("support-bundle-location", "s", "", "path to support bundle archive, directory, or URL")
 	cmd.Flags().StringP("token", "t", "", "API token for authentication when fetching on-line bundles")
+	cmd.Flags().Bool("enable-auth", false, "enable token-based authentication for kubectl commands")
 	cmd.Flags().Bool("debug", false, "enable debug logging. This will include HTTP response bodies in logs.")
 	return cmd
 }

--- a/cli/shell.go
+++ b/cli/shell.go
@@ -22,8 +22,8 @@ import (
 func ShellCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "shell",
-		Short:         "Start interractive shell",
-		Long:          `Start interractive shell`,
+		Short:         "Start interactive shell",
+		Long:          `Start interactive shell`,
 		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: false,
@@ -132,11 +132,30 @@ func ShellCmd() *cobra.Command {
 				return startShellAndWait(cdCmd)
 			}
 
-			kubeConfig, err = api.StartAPIServer(clusterData, logOutput)
+			// Generate auth token and TLS certificate if required or enabled
+			var authToken string
+			var tlsCert *api.TLSCertificate
+			if api.AuthRequired || v.GetBool("enable-auth") {
+				authToken, err = api.GenerateToken()
+				if err != nil {
+					return errors.Wrap(err, "failed to generate auth token")
+				}
+
+				tlsCert, err = api.GenerateSelfSignedCert()
+				if err != nil {
+					return errors.Wrap(err, "failed to generate TLS certificate")
+				}
+			}
+
+			kubeConfig, err = api.StartAPIServer(clusterData, logOutput, authToken, tlsCert)
 			if err != nil {
 				return errors.Wrap(err, "failed to create api server")
 			}
 			defer os.RemoveAll(kubeConfig)
+
+			if authToken != "" {
+				fmt.Printf("Authentication is enabled\n")
+			}
 
 			cmds := []string{
 				fmt.Sprintf("export KUBECONFIG=%s", kubeConfig),
@@ -158,6 +177,7 @@ func ShellCmd() *cobra.Command {
 
 	cmd.Flags().StringP("support-bundle-location", "s", "", "path to support bundle archive, directory, or URL")
 	cmd.Flags().StringP("token", "t", "", "API token for authentication when fetching on-line bundles")
+	cmd.Flags().Bool("enable-auth", false, "enable token-based authentication for kubectl commands")
 	cmd.Flags().Bool("cd-bundle", false, "Change directory to the support bundle path after starting the shell")
 	cmd.Flags().Bool("debug", false, "enable debug logging. This will include HTTP response bodies in logs.")
 	cmd.Flags().StringP("command", "c", "", "Run a command in the shell instead of starting an interactive session")

--- a/cli/shell.go
+++ b/cli/shell.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -37,14 +38,6 @@ func ShellCmd() *cobra.Command {
 			deleteBundleDir := false
 
 			logOutput := os.Stderr
-			logFile, err := os.CreateTemp("", "sbctl-server-*.log")
-			if err == nil {
-				defer logFile.Close()
-				defer os.RemoveAll(logFile.Name())
-				fmt.Printf("SBCTL logs will be written to %s\n", logFile.Name())
-				log.SetOutput(logFile)
-				logOutput = logFile
-			}
 
 			cleanup := func() {
 				if kubeConfig != "" {
@@ -70,6 +63,23 @@ func ShellCmd() *cobra.Command {
 			}()
 
 			v := viper.GetViper()
+
+			logPath := v.GetString("log-file")
+			if logPath == "" {
+				homeDir, err := os.UserHomeDir()
+				if err == nil {
+					logPath = filepath.Join(homeDir, "sbctl-server.log")
+				}
+			}
+			if logPath != "" {
+				logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+				if err == nil {
+					defer logFile.Close()
+					fmt.Printf("SBCTL logs will be written to %s\n", logPath)
+					log.SetOutput(logFile)
+					logOutput = logFile
+				}
+			}
 
 			// This only works with generated config, so let's make sure we don't mess up user's real files.
 			bundleLocation := v.GetString("support-bundle-location")
@@ -181,6 +191,7 @@ func ShellCmd() *cobra.Command {
 	cmd.Flags().Bool("cd-bundle", false, "Change directory to the support bundle path after starting the shell")
 	cmd.Flags().Bool("debug", false, "enable debug logging. This will include HTTP response bodies in logs.")
 	cmd.Flags().StringP("command", "c", "", "Run a command in the shell instead of starting an interactive session")
+	cmd.Flags().String("log-file", "", "path to log file (default: ~/sbctl-server.log, env: SBCTL_LOG_FILE)")
 	return cmd
 }
 

--- a/pkg/api/auth_optional.go
+++ b/pkg/api/auth_optional.go
@@ -1,0 +1,8 @@
+//go:build !auth_required
+// +build !auth_required
+
+package api
+
+// AuthRequired indicates whether authentication is required at compile time.
+// This file is included when the auth_required build tag is NOT set.
+const AuthRequired = false

--- a/pkg/api/auth_required.go
+++ b/pkg/api/auth_required.go
@@ -1,0 +1,9 @@
+//go:build auth_required
+// +build auth_required
+
+package api
+
+// AuthRequired indicates whether authentication is required at compile time.
+// This file is included when the auth_required build tag IS set.
+// Build with: go build -tags auth_required
+const AuthRequired = true

--- a/pkg/api/auth_test.go
+++ b/pkg/api/auth_test.go
@@ -1,0 +1,282 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAuthMiddleware_ValidToken(t *testing.T) {
+	expectedToken := "test-token-12345"
+	called := false
+
+	// Create a test handler that should be called
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Wrap with auth middleware
+	middleware := authMiddleware(expectedToken)
+	handler := middleware(nextHandler)
+
+	// Create request with valid token
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+expectedToken)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if !called {
+		t.Error("Next handler was not called with valid token")
+	}
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Status code = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestAuthMiddleware_InvalidToken(t *testing.T) {
+	expectedToken := "correct-token"
+	called := false
+
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	middleware := authMiddleware(expectedToken)
+	handler := middleware(nextHandler)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if called {
+		t.Error("Next handler was called with invalid token")
+	}
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Status code = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+
+	var response errorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if response.Error != "invalid token" {
+		t.Errorf("Error message = %q, want %q", response.Error, "invalid token")
+	}
+}
+
+func TestAuthMiddleware_MissingHeader(t *testing.T) {
+	expectedToken := "test-token"
+	called := false
+
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	middleware := authMiddleware(expectedToken)
+	handler := middleware(nextHandler)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	// No Authorization header set
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if called {
+		t.Error("Next handler was called without authorization header")
+	}
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Status code = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+
+	var response errorResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if response.Error != "missing authorization header" {
+		t.Errorf("Error message = %q, want %q", response.Error, "missing authorization header")
+	}
+}
+
+func TestAuthMiddleware_MalformedBearer(t *testing.T) {
+	testCases := []struct {
+		name   string
+		header string
+	}{
+		{"No Bearer prefix", "test-token"},
+		{"Wrong prefix", "Basic test-token"},
+		{"Lowercase bearer", "bearer test-token"},
+		{"No space", "Bearertest-token"},
+		{"Multiple spaces", "Bearer  test-token"},
+		{"Empty after Bearer", "Bearer "},
+		{"Just Bearer", "Bearer"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			expectedToken := "test-token"
+			called := false
+
+			nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+			})
+
+			middleware := authMiddleware(expectedToken)
+			handler := middleware(nextHandler)
+
+			req := httptest.NewRequest("GET", "/test", nil)
+			req.Header.Set("Authorization", tc.header)
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			if called {
+				t.Errorf("Next handler was called with malformed header: %q", tc.header)
+			}
+
+			if w.Code != http.StatusUnauthorized {
+				t.Errorf("Status code = %d, want %d", w.Code, http.StatusUnauthorized)
+			}
+		})
+	}
+}
+
+func TestAuthMiddleware_EmptyToken(t *testing.T) {
+	expectedToken := "test-token"
+	called := false
+
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	middleware := authMiddleware(expectedToken)
+	handler := middleware(nextHandler)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer ")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if called {
+		t.Error("Next handler was called with empty token")
+	}
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Status code = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestAuthMiddleware_CaseSensitiveToken(t *testing.T) {
+	expectedToken := "TestToken123"
+	called := false
+
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	})
+
+	middleware := authMiddleware(expectedToken)
+	handler := middleware(nextHandler)
+
+	// Try with different case
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer testtoken123")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if called {
+		t.Error("Next handler was called with wrong case token (tokens should be case-sensitive)")
+	}
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("Status code = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestAuthMiddleware_ContentType(t *testing.T) {
+	expectedToken := "test-token"
+
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	middleware := authMiddleware(expectedToken)
+	handler := middleware(nextHandler)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	contentType := w.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", contentType, "application/json")
+	}
+}
+
+func TestAuthMiddleware_MultipleRequests(t *testing.T) {
+	expectedToken := "test-token"
+	callCount := 0
+
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middleware := authMiddleware(expectedToken)
+	handler := middleware(nextHandler)
+
+	// Make multiple requests with valid token
+	for i := 0; i < 5; i++ {
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.Header.Set("Authorization", "Bearer "+expectedToken)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Request %d: Status code = %d, want %d", i, w.Code, http.StatusOK)
+		}
+	}
+
+	if callCount != 5 {
+		t.Errorf("Handler called %d times, want 5", callCount)
+	}
+}
+
+func TestAuthMiddleware_PreservesRequestContext(t *testing.T) {
+	expectedToken := "test-token"
+	contextPreserved := false
+
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check if we can still access request properties
+		if r.Method == "GET" && r.URL.Path == "/test" {
+			contextPreserved = true
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	middleware := authMiddleware(expectedToken)
+	handler := middleware(nextHandler)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+expectedToken)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if !contextPreserved {
+		t.Error("Request context was not preserved through middleware")
+	}
+}
+
+// Made with Bob

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
@@ -8,8 +9,57 @@ import (
 	"github.com/pkg/errors"
 )
 
-func createConfigFile(endPoint string) (string, error) {
-	ctxTemplate := `
+func createConfigFile(endPoint string, token string, tlsCert *TLSCertificate) (string, error) {
+	var configString string
+
+	if token != "" && tlsCert != nil {
+		// HTTPS with bearer token authentication
+		// Include CA certificate data for TLS verification
+		certData := base64.StdEncoding.EncodeToString(tlsCert.CertPEM)
+		configString = fmt.Sprintf(`apiVersion: v1
+kind: Config
+preferences: {}
+current-context: default
+clusters:
+- name: default
+  cluster:
+    server: %s
+    certificate-authority-data: %s
+contexts:
+- name: default
+  context:
+    cluster: default
+    user: default
+users:
+- name: default
+  user:
+    token: %s
+`, endPoint, certData, token)
+	} else if token != "" {
+		// HTTP with bearer token (shouldn't happen, but handle gracefully)
+		// Use insecure-skip-tls-verify as fallback
+		configString = fmt.Sprintf(`apiVersion: v1
+kind: Config
+preferences: {}
+current-context: default
+clusters:
+- name: default
+  cluster:
+    server: %s
+    insecure-skip-tls-verify: true
+contexts:
+- name: default
+  context:
+    cluster: default
+    user: default
+users:
+- name: default
+  user:
+    token: %s
+`, endPoint, token)
+	} else {
+		// No authentication
+		ctxTemplate := `
 apiVersion: v1
 kind: Config
 preferences: {}
@@ -27,8 +77,9 @@ users:
 - name: default
   user: {}
 `
+		configString = fmt.Sprintf(ctxTemplate, endPoint)
+	}
 
-	configString := fmt.Sprintf(ctxTemplate, endPoint)
 	kubeconfigFile, err := os.CreateTemp("", "local-kubeconfig-")
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create config file")

--- a/pkg/api/client_test.go
+++ b/pkg/api/client_test.go
@@ -1,0 +1,314 @@
+package api
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestCreateConfigFile_WithoutAuth(t *testing.T) {
+	endpoint := "http://127.0.0.1:12345"
+
+	configPath, err := createConfigFile(endpoint, "", nil)
+	if err != nil {
+		t.Fatalf("createConfigFile() failed: %v", err)
+	}
+	defer os.Remove(configPath)
+
+	// Read the config file
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("Failed to read config file: %v", err)
+	}
+
+	// Parse as YAML
+	var config map[string]interface{}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Failed to parse config as YAML: %v", err)
+	}
+
+	// Verify structure
+	if config["apiVersion"] != "v1" {
+		t.Errorf("apiVersion = %v, want v1", config["apiVersion"])
+	}
+
+	if config["kind"] != "Config" {
+		t.Errorf("kind = %v, want Config", config["kind"])
+	}
+
+	// Check clusters
+	clusters, ok := config["clusters"].([]interface{})
+	if !ok || len(clusters) == 0 {
+		t.Fatal("clusters not found or empty")
+	}
+
+	cluster := clusters[0].(map[interface{}]interface{})
+	clusterData := cluster["cluster"].(map[interface{}]interface{})
+
+	if clusterData["server"] != endpoint {
+		t.Errorf("server = %v, want %v", clusterData["server"], endpoint)
+	}
+
+	// Verify no token in users
+	users, ok := config["users"].([]interface{})
+	if !ok || len(users) == 0 {
+		t.Fatal("users not found or empty")
+	}
+
+	user := users[0].(map[interface{}]interface{})
+	userData := user["user"].(map[interface{}]interface{})
+
+	if _, hasToken := userData["token"]; hasToken {
+		t.Error("Token should not be present when auth is disabled")
+	}
+}
+
+func TestCreateConfigFile_WithAuth(t *testing.T) {
+	endpoint := "https://127.0.0.1:12345"
+	token := "test-token-12345"
+
+	// Generate a test TLS certificate
+	tlsCert, err := GenerateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("Failed to generate TLS cert: %v", err)
+	}
+
+	configPath, err := createConfigFile(endpoint, token, tlsCert)
+	if err != nil {
+		t.Fatalf("createConfigFile() failed: %v", err)
+	}
+	defer os.Remove(configPath)
+
+	// Read the config file
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("Failed to read config file: %v", err)
+	}
+
+	// Parse as YAML
+	var config map[string]interface{}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Failed to parse config as YAML: %v", err)
+	}
+
+	// Check clusters with TLS cert
+	clusters, ok := config["clusters"].([]interface{})
+	if !ok || len(clusters) == 0 {
+		t.Fatal("clusters not found or empty")
+	}
+
+	cluster := clusters[0].(map[interface{}]interface{})
+	clusterData := cluster["cluster"].(map[interface{}]interface{})
+
+	if clusterData["server"] != endpoint {
+		t.Errorf("server = %v, want %v", clusterData["server"], endpoint)
+	}
+
+	// Verify certificate-authority-data is present
+	if _, hasCert := clusterData["certificate-authority-data"]; !hasCert {
+		t.Error("certificate-authority-data should be present when TLS is enabled")
+	}
+
+	// Verify token in users
+	users, ok := config["users"].([]interface{})
+	if !ok || len(users) == 0 {
+		t.Fatal("users not found or empty")
+	}
+
+	user := users[0].(map[interface{}]interface{})
+	userData := user["user"].(map[interface{}]interface{})
+
+	actualToken, hasToken := userData["token"]
+	if !hasToken {
+		t.Error("Token should be present when auth is enabled")
+	}
+
+	if actualToken != token {
+		t.Errorf("token = %v, want %v", actualToken, token)
+	}
+}
+
+func TestCreateConfigFile_TLSCertIncluded(t *testing.T) {
+	endpoint := "https://127.0.0.1:12345"
+	token := "test-token"
+
+	tlsCert, err := GenerateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("Failed to generate TLS cert: %v", err)
+	}
+
+	configPath, err := createConfigFile(endpoint, token, tlsCert)
+	if err != nil {
+		t.Fatalf("createConfigFile() failed: %v", err)
+	}
+	defer os.Remove(configPath)
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("Failed to read config file: %v", err)
+	}
+
+	// Verify the certificate data is base64 encoded and present
+	if !strings.Contains(string(data), "certificate-authority-data:") {
+		t.Error("certificate-authority-data not found in config")
+	}
+
+	var config map[string]interface{}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Failed to parse config as YAML: %v", err)
+	}
+
+	clusters := config["clusters"].([]interface{})
+	cluster := clusters[0].(map[interface{}]interface{})
+	clusterData := cluster["cluster"].(map[interface{}]interface{})
+
+	certData, ok := clusterData["certificate-authority-data"].(string)
+	if !ok {
+		t.Fatal("certificate-authority-data is not a string")
+	}
+
+	if len(certData) == 0 {
+		t.Error("certificate-authority-data is empty")
+	}
+}
+
+func TestCreateConfigFile_TokenIncluded(t *testing.T) {
+	endpoint := "https://127.0.0.1:12345"
+	expectedToken := "my-secret-token-12345"
+
+	tlsCert, err := GenerateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("Failed to generate TLS cert: %v", err)
+	}
+
+	configPath, err := createConfigFile(endpoint, expectedToken, tlsCert)
+	if err != nil {
+		t.Fatalf("createConfigFile() failed: %v", err)
+	}
+	defer os.Remove(configPath)
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("Failed to read config file: %v", err)
+	}
+
+	// Verify token is in the file
+	if !strings.Contains(string(data), expectedToken) {
+		t.Error("Token not found in config file")
+	}
+
+	var config map[string]interface{}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Failed to parse config as YAML: %v", err)
+	}
+
+	users := config["users"].([]interface{})
+	user := users[0].(map[interface{}]interface{})
+	userData := user["user"].(map[interface{}]interface{})
+
+	actualToken := userData["token"].(string)
+	if actualToken != expectedToken {
+		t.Errorf("token = %q, want %q", actualToken, expectedToken)
+	}
+}
+
+func TestCreateConfigFile_FileCreated(t *testing.T) {
+	endpoint := "http://127.0.0.1:12345"
+
+	configPath, err := createConfigFile(endpoint, "", nil)
+	if err != nil {
+		t.Fatalf("createConfigFile() failed: %v", err)
+	}
+	defer os.Remove(configPath)
+
+	// Verify file exists
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Error("Config file was not created")
+	}
+
+	// Verify file is readable
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Errorf("Config file is not readable: %v", err)
+	}
+
+	if len(data) == 0 {
+		t.Error("Config file is empty")
+	}
+}
+
+func TestCreateConfigFile_ValidYAML(t *testing.T) {
+	testCases := []struct {
+		name     string
+		endpoint string
+		token    string
+		hasTLS   bool
+	}{
+		{"No auth", "http://127.0.0.1:8080", "", false},
+		{"With auth", "https://127.0.0.1:8443", "token123", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var tlsCert *TLSCertificate
+			if tc.hasTLS {
+				var err error
+				tlsCert, err = GenerateSelfSignedCert()
+				if err != nil {
+					t.Fatalf("Failed to generate TLS cert: %v", err)
+				}
+			}
+
+			configPath, err := createConfigFile(tc.endpoint, tc.token, tlsCert)
+			if err != nil {
+				t.Fatalf("createConfigFile() failed: %v", err)
+			}
+			defer os.Remove(configPath)
+
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatalf("Failed to read config file: %v", err)
+			}
+
+			// Verify it's valid YAML
+			var config map[string]interface{}
+			if err := yaml.Unmarshal(data, &config); err != nil {
+				t.Errorf("Config is not valid YAML: %v", err)
+			}
+		})
+	}
+}
+
+func TestCreateConfigFile_CurrentContext(t *testing.T) {
+	endpoint := "http://127.0.0.1:12345"
+
+	configPath, err := createConfigFile(endpoint, "", nil)
+	if err != nil {
+		t.Fatalf("createConfigFile() failed: %v", err)
+	}
+	defer os.Remove(configPath)
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("Failed to read config file: %v", err)
+	}
+
+	var config map[string]interface{}
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		t.Fatalf("Failed to parse config as YAML: %v", err)
+	}
+
+	// Verify current-context is set
+	currentContext, ok := config["current-context"]
+	if !ok {
+		t.Error("current-context not found in config")
+	}
+
+	if currentContext != "default" {
+		t.Errorf("current-context = %v, want default", currentContext)
+	}
+}
+
+// Made with Bob

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -3,6 +3,8 @@ package api
 import (
 	"bytes"
 	"context"
+	"crypto/subtle"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -77,13 +79,64 @@ type errorResponse struct {
 	Error string `json:"error"`
 }
 
-func StartAPIServer(clusterData sbctl.ClusterData, logOutput io.Writer) (string, error) {
+// authMiddleware creates middleware that validates bearer token authentication
+// All endpoints require authentication when enabled
+func authMiddleware(expectedToken string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Extract Authorization header
+			authHeader := r.Header.Get("Authorization")
+			if authHeader == "" {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				json.NewEncoder(w).Encode(errorResponse{
+					Error: "missing authorization header",
+				})
+				return
+			}
+
+			// Check for Bearer token format
+			const bearerPrefix = "Bearer "
+			if !strings.HasPrefix(authHeader, bearerPrefix) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				json.NewEncoder(w).Encode(errorResponse{
+					Error: "invalid authorization format, expected 'Bearer <token>'",
+				})
+				return
+			}
+
+			// Extract token
+			token := strings.TrimPrefix(authHeader, bearerPrefix)
+
+			// Constant-time comparison to prevent timing attacks
+			if subtle.ConstantTimeCompare([]byte(token), []byte(expectedToken)) != 1 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				json.NewEncoder(w).Encode(errorResponse{
+					Error: "invalid token",
+				})
+				return
+			}
+
+			// Token is valid, proceed to next handler
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func StartAPIServer(clusterData sbctl.ClusterData, logOutput io.Writer, authToken string, tlsCert *TLSCertificate) (string, error) {
 	h := handler{
 		clusterData: clusterData,
 	}
 
 	r := mux.NewRouter()
 	r.Use(dumpRequestResponse)
+
+	// Apply auth middleware if token is provided
+	if authToken != "" {
+		r.Use(authMiddleware(authToken))
+	}
 
 	r.HandleFunc("/api", h.getAPI)
 	apiRouter := r.PathPrefix("/api").Subrouter()
@@ -120,10 +173,32 @@ func StartAPIServer(clusterData sbctl.ClusterData, logOutput io.Writer) (string,
 		return "", errors.Wrap(err, "listening on port")
 	}
 
+	// Determine if we're using TLS
+	useTLS := tlsCert != nil
+	scheme := "http"
+	if useTLS {
+		scheme = "https"
+	}
+
 	go func(server *http.Server, logsPipe *io.PipeWriter) {
 		defer logsPipe.Close()
 
-		err := server.Serve(listener)
+		var err error
+		if useTLS {
+			// Create TLS config from certificate
+			cert, err := tls.X509KeyPair(tlsCert.CertPEM, tlsCert.KeyPEM)
+			if err != nil {
+				log.Panic(errors.Wrap(err, "failed to load TLS certificate"))
+			}
+			server.TLSConfig = &tls.Config{
+				Certificates: []tls.Certificate{cert},
+				MinVersion:   tls.VersionTLS12,
+			}
+			err = server.ServeTLS(listener, "", "")
+		} else {
+			err = server.Serve(listener)
+		}
+
 		if !errors.Is(err, http.ErrServerClosed) {
 			log.Panic(err)
 		}
@@ -133,11 +208,32 @@ func StartAPIServer(clusterData sbctl.ClusterData, logOutput io.Writer) (string,
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	// Create HTTP client that skips TLS verification for health check
+	// This is safe because:
+	// 1. We're only connecting to localhost (127.0.0.1)
+	// 2. We're using a self-signed certificate we just generated
+	// 3. This is only for the initial health check, not for user traffic
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+
 WAIT_FOR_SERVER:
 	for {
 		select {
 		case <-time.After(1):
-			resp, err := http.Get(fmt.Sprintf("http://%s/api/v1", listener.Addr()))
+			req, err := http.NewRequest("GET", fmt.Sprintf("%s://%s/api/v1", scheme, listener.Addr()), nil)
+			if err != nil {
+				continue
+			}
+			// Add auth token to health check if auth is enabled
+			if authToken != "" {
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
+			}
+			resp, err := httpClient.Do(req)
 			if err == nil && resp.StatusCode == http.StatusOK {
 				break WAIT_FOR_SERVER
 			}
@@ -146,7 +242,7 @@ WAIT_FOR_SERVER:
 		}
 	}
 
-	configFile, err := createConfigFile(fmt.Sprintf("http://%s", listener.Addr()))
+	configFile, err := createConfigFile(fmt.Sprintf("%s://%s", scheme, listener.Addr()), authToken, tlsCert)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create clientset for local endpoint")
 	}

--- a/pkg/api/tls.go
+++ b/pkg/api/tls.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+)
+
+// TLSCertificate holds a PEM-encoded certificate and private key
+type TLSCertificate struct {
+	CertPEM []byte
+	KeyPEM  []byte
+}
+
+// GenerateSelfSignedCert generates a self-signed TLS certificate for localhost.
+// The certificate is valid for 24 hours and includes localhost, 127.0.0.1, and ::1.
+func GenerateSelfSignedCert() (*TLSCertificate, error) {
+	// Generate private key using ECDSA P-256 (faster and smaller than RSA)
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate private key: %w", err)
+	}
+
+	// Generate a random serial number
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate serial number: %w", err)
+	}
+
+	// Create certificate template
+	notBefore := time.Now()
+	notAfter := notBefore.Add(24 * time.Hour) // Valid for 24 hours
+
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"sbctl"},
+			CommonName:   "sbctl-localhost",
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1"), net.ParseIP("::1")},
+	}
+
+	// Create self-signed certificate
+	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create certificate: %w", err)
+	}
+
+	// Encode certificate to PEM
+	certPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	})
+
+	// Encode private key to PEM
+	privateKeyBytes, err := x509.MarshalECPrivateKey(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal private key: %w", err)
+	}
+
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: privateKeyBytes,
+	})
+
+	return &TLSCertificate{
+		CertPEM: certPEM,
+		KeyPEM:  keyPEM,
+	}, nil
+}

--- a/pkg/api/tls_test.go
+++ b/pkg/api/tls_test.go
@@ -1,0 +1,221 @@
+package api
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestGenerateSelfSignedCert_Success(t *testing.T) {
+	cert, err := GenerateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert() failed: %v", err)
+	}
+
+	if cert == nil {
+		t.Fatal("GenerateSelfSignedCert() returned nil certificate")
+	}
+
+	if len(cert.CertPEM) == 0 {
+		t.Error("Certificate PEM is empty")
+	}
+
+	if len(cert.KeyPEM) == 0 {
+		t.Error("Private key PEM is empty")
+	}
+}
+
+func TestGenerateSelfSignedCert_ValidityPeriod(t *testing.T) {
+	cert, err := GenerateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert() failed: %v", err)
+	}
+
+	// Parse the certificate
+	block, _ := pem.Decode(cert.CertPEM)
+	if block == nil {
+		t.Fatal("Failed to decode certificate PEM")
+	}
+
+	x509Cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse certificate: %v", err)
+	}
+
+	// Check validity period is approximately 24 hours
+	now := time.Now()
+	expectedExpiry := now.Add(24 * time.Hour)
+
+	// Allow 1 minute tolerance for test execution time
+	tolerance := 1 * time.Minute
+
+	if x509Cert.NotBefore.After(now.Add(tolerance)) {
+		t.Errorf("Certificate NotBefore is in the future: %v", x509Cert.NotBefore)
+	}
+
+	if x509Cert.NotBefore.Before(now.Add(-tolerance)) {
+		t.Errorf("Certificate NotBefore is too far in the past: %v", x509Cert.NotBefore)
+	}
+
+	if x509Cert.NotAfter.After(expectedExpiry.Add(tolerance)) {
+		t.Errorf("Certificate NotAfter is too far in the future: %v (expected ~%v)", x509Cert.NotAfter, expectedExpiry)
+	}
+
+	if x509Cert.NotAfter.Before(expectedExpiry.Add(-tolerance)) {
+		t.Errorf("Certificate NotAfter is too soon: %v (expected ~%v)", x509Cert.NotAfter, expectedExpiry)
+	}
+}
+
+func TestGenerateSelfSignedCert_LocalhostNames(t *testing.T) {
+	cert, err := GenerateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert() failed: %v", err)
+	}
+
+	// Parse the certificate
+	block, _ := pem.Decode(cert.CertPEM)
+	if block == nil {
+		t.Fatal("Failed to decode certificate PEM")
+	}
+
+	x509Cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse certificate: %v", err)
+	}
+
+	// Check DNS names
+	expectedDNS := []string{"localhost"}
+	if len(x509Cert.DNSNames) != len(expectedDNS) {
+		t.Errorf("Expected %d DNS names, got %d", len(expectedDNS), len(x509Cert.DNSNames))
+	}
+
+	for _, expected := range expectedDNS {
+		found := false
+		for _, actual := range x509Cert.DNSNames {
+			if actual == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected DNS name %s not found in certificate", expected)
+		}
+	}
+
+	// Check IP addresses
+	expectedIPs := []string{"127.0.0.1", "::1"}
+	if len(x509Cert.IPAddresses) != len(expectedIPs) {
+		t.Errorf("Expected %d IP addresses, got %d", len(expectedIPs), len(x509Cert.IPAddresses))
+	}
+
+	for _, expectedIP := range expectedIPs {
+		found := false
+		expected := net.ParseIP(expectedIP)
+		for _, actual := range x509Cert.IPAddresses {
+			if actual.Equal(expected) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected IP address %s not found in certificate", expectedIP)
+		}
+	}
+}
+
+func TestGenerateSelfSignedCert_PEMEncoding(t *testing.T) {
+	cert, err := GenerateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert() failed: %v", err)
+	}
+
+	// Verify certificate PEM
+	certBlock, _ := pem.Decode(cert.CertPEM)
+	if certBlock == nil {
+		t.Fatal("Failed to decode certificate PEM")
+	}
+	if certBlock.Type != "CERTIFICATE" {
+		t.Errorf("Certificate PEM type = %s, want CERTIFICATE", certBlock.Type)
+	}
+
+	// Verify key PEM
+	keyBlock, _ := pem.Decode(cert.KeyPEM)
+	if keyBlock == nil {
+		t.Fatal("Failed to decode key PEM")
+	}
+	if keyBlock.Type != "EC PRIVATE KEY" {
+		t.Errorf("Key PEM type = %s, want EC PRIVATE KEY", keyBlock.Type)
+	}
+}
+
+func TestGenerateSelfSignedCert_CanLoadAsTLSCertificate(t *testing.T) {
+	cert, err := GenerateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert() failed: %v", err)
+	}
+
+	// Try to load as TLS certificate
+	_, err = tls.X509KeyPair(cert.CertPEM, cert.KeyPEM)
+	if err != nil {
+		t.Errorf("Failed to load certificate as TLS certificate: %v", err)
+	}
+}
+
+func TestGenerateSelfSignedCert_KeyUsage(t *testing.T) {
+	cert, err := GenerateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert() failed: %v", err)
+	}
+
+	// Parse the certificate
+	block, _ := pem.Decode(cert.CertPEM)
+	if block == nil {
+		t.Fatal("Failed to decode certificate PEM")
+	}
+
+	x509Cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse certificate: %v", err)
+	}
+
+	// Check key usage
+	expectedKeyUsage := x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature
+	if x509Cert.KeyUsage != expectedKeyUsage {
+		t.Errorf("KeyUsage = %v, want %v", x509Cert.KeyUsage, expectedKeyUsage)
+	}
+
+	// Check extended key usage
+	if len(x509Cert.ExtKeyUsage) != 1 {
+		t.Errorf("Expected 1 ExtKeyUsage, got %d", len(x509Cert.ExtKeyUsage))
+	}
+	if len(x509Cert.ExtKeyUsage) > 0 && x509Cert.ExtKeyUsage[0] != x509.ExtKeyUsageServerAuth {
+		t.Errorf("ExtKeyUsage[0] = %v, want %v", x509Cert.ExtKeyUsage[0], x509.ExtKeyUsageServerAuth)
+	}
+}
+
+func TestGenerateSelfSignedCert_Uniqueness(t *testing.T) {
+	// Generate multiple certificates and ensure they're unique
+	cert1, err := GenerateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert() failed: %v", err)
+	}
+
+	cert2, err := GenerateSelfSignedCert()
+	if err != nil {
+		t.Fatalf("GenerateSelfSignedCert() failed: %v", err)
+	}
+
+	// Certificates should be different
+	if string(cert1.CertPEM) == string(cert2.CertPEM) {
+		t.Error("Generated certificates are identical, expected unique certificates")
+	}
+
+	if string(cert1.KeyPEM) == string(cert2.KeyPEM) {
+		t.Error("Generated keys are identical, expected unique keys")
+	}
+}
+
+// Made with Bob

--- a/pkg/api/token.go
+++ b/pkg/api/token.go
@@ -1,0 +1,17 @@
+package api
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+)
+
+// GenerateToken generates a cryptographically secure random token.
+// The token is 256 bits (32 bytes) encoded as base64 URL-safe string.
+func GenerateToken() (string, error) {
+	b := make([]byte, 32) // 256 bits
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate random token: %w", err)
+	}
+	return base64.URLEncoding.EncodeToString(b), nil
+}

--- a/pkg/api/token_test.go
+++ b/pkg/api/token_test.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestGenerateToken_Success(t *testing.T) {
+	token, err := GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken() failed: %v", err)
+	}
+	if token == "" {
+		t.Error("GenerateToken() returned empty token")
+	}
+}
+
+func TestGenerateToken_Length(t *testing.T) {
+	token, err := GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken() failed: %v", err)
+	}
+
+	// Decode the base64 token to check the underlying byte length
+	decoded, err := base64.URLEncoding.DecodeString(token)
+	if err != nil {
+		t.Fatalf("Failed to decode token: %v", err)
+	}
+
+	expectedLength := 32 // 256 bits = 32 bytes
+	if len(decoded) != expectedLength {
+		t.Errorf("Token length = %d bytes, want %d bytes", len(decoded), expectedLength)
+	}
+}
+
+func TestGenerateToken_Uniqueness(t *testing.T) {
+	// Generate multiple tokens and ensure they're all unique
+	tokens := make(map[string]bool)
+	iterations := 100
+
+	for i := 0; i < iterations; i++ {
+		token, err := GenerateToken()
+		if err != nil {
+			t.Fatalf("GenerateToken() failed on iteration %d: %v", i, err)
+		}
+
+		if tokens[token] {
+			t.Errorf("GenerateToken() produced duplicate token: %s", token)
+		}
+		tokens[token] = true
+	}
+
+	if len(tokens) != iterations {
+		t.Errorf("Expected %d unique tokens, got %d", iterations, len(tokens))
+	}
+}
+
+func TestGenerateToken_Base64URLEncoding(t *testing.T) {
+	token, err := GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken() failed: %v", err)
+	}
+
+	// Verify it's valid base64 URL encoding
+	_, err = base64.URLEncoding.DecodeString(token)
+	if err != nil {
+		t.Errorf("Token is not valid base64 URL encoding: %v", err)
+	}
+
+	// Verify it doesn't contain characters invalid for URL encoding
+	// Base64 URL encoding uses: A-Z, a-z, 0-9, -, _
+	for _, char := range token {
+		if !((char >= 'A' && char <= 'Z') ||
+			(char >= 'a' && char <= 'z') ||
+			(char >= '0' && char <= '9') ||
+			char == '-' || char == '_' || char == '=') {
+			t.Errorf("Token contains invalid character for URL encoding: %c", char)
+		}
+	}
+}
+
+func TestGenerateToken_NotEmpty(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		token, err := GenerateToken()
+		if err != nil {
+			t.Fatalf("GenerateToken() failed: %v", err)
+		}
+		if len(token) == 0 {
+			t.Error("GenerateToken() returned empty string")
+		}
+	}
+}
+
+// Made with Bob

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -1,0 +1,314 @@
+package tests
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/replicatedhq/sbctl/pkg/api"
+	"github.com/replicatedhq/sbctl/pkg/sbctl"
+	yaml "gopkg.in/yaml.v2"
+)
+
+var _ = Describe("Authentication", func() {
+	var (
+		authToken        string
+		tlsCert          *api.TLSCertificate
+		kubeConfig       string
+		authenticatedURL string
+		httpClient       *http.Client
+	)
+
+	BeforeEach(func() {
+		// Load cluster data
+		clusterData, err := sbctl.FindClusterData("./support-bundle")
+		Expect(err).NotTo(HaveOccurred())
+
+		// Generate auth token and TLS certificate
+		authToken, err = api.GenerateToken()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(authToken).NotTo(BeEmpty())
+
+		tlsCert, err = api.GenerateSelfSignedCert()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tlsCert).NotTo(BeNil())
+
+		// Start API server with authentication
+		kubeConfig, err = api.StartAPIServer(clusterData, os.Stderr, authToken, tlsCert)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Get the endpoint
+		endpoint, err := getAPIEndpoint(kubeConfig)
+		Expect(err).NotTo(HaveOccurred())
+		authenticatedURL = endpoint
+
+		// Create HTTP client that skips TLS verification (for self-signed cert)
+		transport := &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+		httpClient = &http.Client{
+			Transport: transport,
+		}
+	})
+
+	AfterEach(func() {
+		if kubeConfig != "" {
+			os.RemoveAll(kubeConfig)
+		}
+	})
+
+	Context("When authentication is enabled", func() {
+		It("should reject requests without authorization header", func() {
+			req, err := http.NewRequest("GET", authenticatedURL+"/api/v1", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := httpClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+
+			var errorResp map[string]string
+			err = json.NewDecoder(resp.Body).Decode(&errorResp)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(errorResp["error"]).To(ContainSubstring("missing authorization header"))
+		})
+
+		It("should reject requests with invalid token", func() {
+			req, err := http.NewRequest("GET", authenticatedURL+"/api/v1", nil)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Authorization", "Bearer invalid-token")
+
+			resp, err := httpClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+
+			var errorResp map[string]string
+			err = json.NewDecoder(resp.Body).Decode(&errorResp)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(errorResp["error"]).To(ContainSubstring("invalid token"))
+		})
+
+		It("should reject requests with malformed authorization header", func() {
+			testCases := []string{
+				"invalid-token",       // No Bearer prefix
+				"Basic " + authToken,  // Wrong auth type
+				"bearer " + authToken, // Lowercase bearer
+				"Bearer",              // No token
+				"Bearer ",             // Empty token
+			}
+
+			for _, authHeader := range testCases {
+				req, err := http.NewRequest("GET", authenticatedURL+"/api/v1", nil)
+				Expect(err).NotTo(HaveOccurred())
+				req.Header.Set("Authorization", authHeader)
+
+				resp, err := httpClient.Do(req)
+				Expect(err).NotTo(HaveOccurred())
+				resp.Body.Close()
+
+				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized),
+					fmt.Sprintf("Expected 401 for auth header: %q", authHeader))
+			}
+		})
+
+		It("should accept requests with valid token", func() {
+			req, err := http.NewRequest("GET", authenticatedURL+"/api/v1", nil)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Authorization", "Bearer "+authToken)
+			req.Header.Set("Accept", "application/json")
+
+			resp, err := httpClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			// Verify we get actual data back
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(body)).To(BeNumerically(">", 0))
+		})
+
+		It("should protect all endpoints with authentication", func() {
+			endpoints := []string{
+				"/api",
+				"/api/v1",
+				"/api/v1/pods",
+				"/api/v1/namespaces/default/pods",
+				"/apis",
+				"/version",
+			}
+
+			for _, endpoint := range endpoints {
+				// Without token - should fail
+				req, err := http.NewRequest("GET", authenticatedURL+endpoint, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				resp, err := httpClient.Do(req)
+				Expect(err).NotTo(HaveOccurred())
+				resp.Body.Close()
+
+				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized),
+					fmt.Sprintf("Endpoint %s should require authentication", endpoint))
+
+				// With token - should succeed (or at least not return 401)
+				req, err = http.NewRequest("GET", authenticatedURL+endpoint, nil)
+				Expect(err).NotTo(HaveOccurred())
+				req.Header.Set("Authorization", "Bearer "+authToken)
+
+				resp, err = httpClient.Do(req)
+				Expect(err).NotTo(HaveOccurred())
+				resp.Body.Close()
+
+				Expect(resp.StatusCode).NotTo(Equal(http.StatusUnauthorized),
+					fmt.Sprintf("Endpoint %s should accept valid token", endpoint))
+			}
+		})
+
+		It("should include token in generated kubeconfig", func() {
+			configData, err := os.ReadFile(kubeConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			var config map[string]interface{}
+			err = yaml.Unmarshal(configData, &config)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Check users section has token
+			users, ok := config["users"].([]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(len(users)).To(BeNumerically(">", 0))
+
+			user := users[0].(map[interface{}]interface{})
+			userData := user["user"].(map[interface{}]interface{})
+
+			token, hasToken := userData["token"]
+			Expect(hasToken).To(BeTrue(), "Token should be in kubeconfig")
+			Expect(token).To(Equal(authToken))
+		})
+
+		It("should include TLS certificate in generated kubeconfig", func() {
+			configData, err := os.ReadFile(kubeConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			var config map[string]interface{}
+			err = yaml.Unmarshal(configData, &config)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Check clusters section has certificate-authority-data
+			clusters, ok := config["clusters"].([]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(len(clusters)).To(BeNumerically(">", 0))
+
+			cluster := clusters[0].(map[interface{}]interface{})
+			clusterData := cluster["cluster"].(map[interface{}]interface{})
+
+			certData, hasCert := clusterData["certificate-authority-data"]
+			Expect(hasCert).To(BeTrue(), "Certificate data should be in kubeconfig")
+			Expect(certData).NotTo(BeEmpty())
+		})
+
+		It("should use HTTPS when authentication is enabled", func() {
+			configData, err := os.ReadFile(kubeConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			var config map[string]interface{}
+			err = yaml.Unmarshal(configData, &config)
+			Expect(err).NotTo(HaveOccurred())
+
+			clusters, ok := config["clusters"].([]interface{})
+			Expect(ok).To(BeTrue())
+
+			cluster := clusters[0].(map[interface{}]interface{})
+			clusterData := cluster["cluster"].(map[interface{}]interface{})
+
+			server := clusterData["server"].(string)
+			Expect(server).To(HavePrefix("https://"), "Server should use HTTPS when auth is enabled")
+		})
+	})
+
+	Context("When authentication is disabled", func() {
+		var (
+			noAuthKubeConfig string
+			noAuthURL        string
+		)
+
+		BeforeEach(func() {
+			clusterData, err := sbctl.FindClusterData("./support-bundle")
+			Expect(err).NotTo(HaveOccurred())
+
+			// Start API server WITHOUT authentication
+			noAuthKubeConfig, err = api.StartAPIServer(clusterData, os.Stderr, "", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			endpoint, err := getAPIEndpoint(noAuthKubeConfig)
+			Expect(err).NotTo(HaveOccurred())
+			noAuthURL = endpoint
+		})
+
+		AfterEach(func() {
+			if noAuthKubeConfig != "" {
+				os.RemoveAll(noAuthKubeConfig)
+			}
+		})
+
+		It("should allow requests without authorization header", func() {
+			req, err := http.NewRequest("GET", noAuthURL+"/api/v1", nil)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Accept", "application/json")
+
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		})
+
+		It("should not include token in generated kubeconfig", func() {
+			configData, err := os.ReadFile(noAuthKubeConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			var config map[string]interface{}
+			err = yaml.Unmarshal(configData, &config)
+			Expect(err).NotTo(HaveOccurred())
+
+			users, ok := config["users"].([]interface{})
+			Expect(ok).To(BeTrue())
+
+			user := users[0].(map[interface{}]interface{})
+			userData := user["user"].(map[interface{}]interface{})
+
+			_, hasToken := userData["token"]
+			Expect(hasToken).To(BeFalse(), "Token should not be in kubeconfig when auth is disabled")
+		})
+
+		It("should use HTTP when authentication is disabled", func() {
+			configData, err := os.ReadFile(noAuthKubeConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			var config map[string]interface{}
+			err = yaml.Unmarshal(configData, &config)
+			Expect(err).NotTo(HaveOccurred())
+
+			clusters, ok := config["clusters"].([]interface{})
+			Expect(ok).To(BeTrue())
+
+			cluster := clusters[0].(map[interface{}]interface{})
+			clusterData := cluster["cluster"].(map[interface{}]interface{})
+
+			server := clusterData["server"].(string)
+			Expect(server).To(HavePrefix("http://"), "Server should use HTTP when auth is disabled")
+		})
+	})
+})
+
+// Made with Bob

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -40,7 +40,7 @@ var _ = BeforeSuite(func() {
 	Expect(clusterData.ClusterResourcesDir).To(Equal("support-bundle/cluster-resources"))
 	Expect(clusterData.ClusterInfoFile).To(Equal("support-bundle/cluster-info/cluster_version.json"))
 
-	kubeConfig, err := api.StartAPIServer(clusterData, os.Stderr)
+	kubeConfig, err := api.StartAPIServer(clusterData, os.Stderr, "", nil)
 	Expect(err).NotTo(HaveOccurred())
 	cleanup := func() error {
 		return os.RemoveAll(kubeConfig)


### PR DESCRIPTION
Log path is configurable via --log-file flag or SBCTL_LOG_FILE env var. 
Previously logs were written to a random temp file that was deleted on exit.